### PR TITLE
Replace `substr` with `preg_replace`

### DIFF
--- a/components/StaticPage.php
+++ b/components/StaticPage.php
@@ -46,9 +46,7 @@ class StaticPage extends ComponentBase
 
         // Remove language prefix in case it exists (e.g. from "/en/my-page" to "/my-page")
         if (class_exists('RainLab\Translate\Behaviors\TranslatableModel')) {
-            if (strpos(substr($url, 1), '/')) { // check if url has language prefix
-                $url = substr($url, 3);
-            }
+            $url = preg_replace('/\/[a-z]{2}\//', '/', $url);
         }
 
         if (!strlen($url)) {

--- a/components/StaticPage.php
+++ b/components/StaticPage.php
@@ -46,7 +46,9 @@ class StaticPage extends ComponentBase
 
         // Remove language prefix in case it exists (e.g. from "/en/my-page" to "/my-page")
         if (class_exists('RainLab\Translate\Behaviors\TranslatableModel')) {
-            $url = substr($url, 3);
+            if (strpos(substr($url, 1), '/')) { // check if url has language prefix
+                $url = substr($url, 3);
+            }
         }
 
         if (!strlen($url)) {


### PR DESCRIPTION
There is not enough check for TranslatableModel, because URL can be without prefix.

For example `/contacts` will became `ntacts` - and component will not find the page.