### PR TITLE
Some small improvements 

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -4,6 +4,7 @@ use Backend\Classes\FormTabs;
 use Backend\Widgets\Form;
 use RainLab\Blog\Models\Post;
 use SureSoftware\PowerSEO\classes\Helper;
+use SureSoftware\PowerSEO\Models\Settings;
 use Cms\Classes\Page;
 use Cms\Classes\Theme;
 use System\Classes\PluginBase;
@@ -62,9 +63,15 @@ class Plugin extends PluginBase
             'filters' => [
                 'generateTitle' => [$this, 'generateTitle'],
                 'generateCanonicalUrl' => [$this, 'generateCanonicalUrl'],
-                'otherMetaTags' => [$this, 'otherMetaTags'],
+                'otherMetaTags' => [$this, 'otherMetaTags'],              
                 'generateOgTags' => [$this, 'generateOgTags']
-            ]
+            ],
+            'functions' => [
+                'getSettings' => function($setting)
+				{
+					return Settings::get($setting);
+				},
+            ],
         ];
     }
 

--- a/components/blogpost/default.htm
+++ b/components/blogpost/default.htm
@@ -4,6 +4,10 @@
         <meta http-equiv="refresh" content="0; url={{post.powerseo_redirect_url}}" />
     {% endif -%}
 
+	{%- if getSettings('other_tags_position') == 'top' %}
+		{{ ''|otherMetaTags|raw }}
+	{% endif -%}
+
     {%- if post.powerseo_title %}
         <title>{{ post.powerseo_title | generateTitle}}</title>
     {% else %}
@@ -36,7 +40,9 @@
         <meta name="robots" content="index,follow">
     {% endif -%}
 
-    {{ ''|otherMetaTags|raw }}
+    {% if getSettings('other_tags_position') != 'top' %}
+        {{ ''|otherMetaTags|raw }}
+    {% endif %}
 
     {{ post|generateOgTags }}
 {% endput %}

--- a/components/blogpost/default.htm
+++ b/components/blogpost/default.htm
@@ -1,32 +1,32 @@
 {% put meta %}
     {% default %}
-    {% if post.powerseo_redirect_url %}
+    {%- if post.powerseo_redirect_url %}
         <meta http-equiv="refresh" content="0; url={{post.powerseo_redirect_url}}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if post.powerseo_title %}
+    {%- if post.powerseo_title %}
         <title>{{ post.powerseo_title | generateTitle}}</title>
     {% else %}
         <title>{{ post.title | generateTitle }}</title>
-    {% endif %}
+    {% endif -%}
 
-    {% if post.powerseo_description %}
+    {%- if post.powerseo_description %}
         <meta name="description" content="{{post.powerseo_description}}">
     {% elseif post.excerpt %}
         <meta name="description" content="{{post.excerpt}}">
-    {% endif %}
+    {% endif -%}
 
-    {% if post.powerseo_keywords %}
+    {%- if post.powerseo_keywords %}
         <meta name="keywords" content="{{post.powerseo_keywords}}">
-    {% endif %}
+    {% endif -%}
 
-    {% if post.powerseo_canonical_url %}
+    {%- if post.powerseo_canonical_url %}
         <link rel="canonical" href="{{post.powerseo_canonical_url}}" />
     {% else %}
         {{ '' | generateCanonicalUrl}}
-    {% endif %}
+    {% endif -%}
 
-    {% if post.powerseo_robot_index and post.powerseo_robot_follow %}
+    {%- if post.powerseo_robot_index and post.powerseo_robot_follow %}
         <meta name="robots" content="{{post.powerseo_robot_index}},{{post.powerseo_robot_follow}}">
     {% elseif post.powerseo_robot_index %}
         <meta name="robots" content="{{post.powerseo_robot_index}},follow">
@@ -34,7 +34,7 @@
         <meta name="robots" content="index,{{post.powerseo_robot_follow}}">
     {% else %}
         <meta name="robots" content="index,follow">
-    {% endif %}
+    {% endif -%}
 
     {{ ''|otherMetaTags|raw }}
 

--- a/components/cmspage/default.htm
+++ b/components/cmspage/default.htm
@@ -5,29 +5,29 @@
 
 {% else %}
 
-    {% if __SELF__.redirect_url %}
+    {%- if __SELF__.redirect_url %}
         <meta http-equiv="refresh" content="0; url={{__SELF__.redirect_url}}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.seo_title %}
+    {%- if __SELF__.seo_title %}
         <title>{{__SELF__.seo_title | generateTitle}}</title>
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.seo_description %}
+    {%- if __SELF__.seo_description %}
         <meta name="description" content="{{__SELF__.seo_description}}">
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.seo_keywords %}
+    {%- if __SELF__.seo_keywords %}
         <meta name="keywords" content="{{__SELF__.seo_keywords}}">
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.canonical_url %}
+    {%- if __SELF__.canonical_url %}
         <link rel="canonical" href="{{__SELF__.canonical_url}}" />
     {% else %}
         {{ '' | generateCanonicalUrl}}
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.robot_index and __SELF__.robot_follow %}
+    {%- if __SELF__.robot_index and __SELF__.robot_follow %}
         <meta name="robots" content="{{__SELF__.robot_index}},{{__SELF__.robot_follow}}">
     {% elseif __SELF__.robot_index %}
         <meta name="robots" content="{{__SELF__.robot_index}},follow">
@@ -35,28 +35,28 @@
         <meta name="robots" content="index,{{__SELF__.robot_follow}}">
     {% else %}
         <meta name="robots" content="index,follow">
-    {% endif %}
+    {% endif -%}
 
     {{ ''|otherMetaTags|raw }}
 
-    {% if __SELF__.ogTitle %}
+    {%- if __SELF__.ogTitle %}
         <meta property="og:title" content="{{ __SELF__.ogTitle }}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.ogUrl %}
+    {%- if __SELF__.ogUrl %}
         <meta property="og:url" content="{{ __SELF__.ogUrl }}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.ogSiteName %}
+    {%- if __SELF__.ogSiteName %}
         <meta property="og:site_name" content="{{ __SELF__.ogSiteName }}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.ogDescription %}
+    {% -if __SELF__.ogDescription %}
         <meta property="og:description" content="{{ __SELF__.ogDescription }}" />
-    {% endif %}
+    {% endif -%}
 
-    {% if __SELF__.ogFbAppId %}
+    {%- if __SELF__.ogFbAppId %}
         <meta property="fb:app_id" content="{{ __SELF__.ogFbAppId  }}" />
-    {% endif %}
+    {% endif -%}
 
 {% endif %}

--- a/components/cmspage/default.htm
+++ b/components/cmspage/default.htm
@@ -9,6 +9,10 @@
         <meta http-equiv="refresh" content="0; url={{__SELF__.redirect_url}}" />
     {% endif -%}
 
+	{%- if getSettings('other_tags_position') == 'top' %}
+		{{ ''|otherMetaTags|raw }}
+	{% endif -%}
+
     {%- if __SELF__.seo_title %}
         <title>{{__SELF__.seo_title | generateTitle}}</title>
     {% endif -%}
@@ -37,7 +41,9 @@
         <meta name="robots" content="index,follow">
     {% endif -%}
 
-    {{ ''|otherMetaTags|raw }}
+	{% if getSettings('other_tags_position') != 'top' %}
+		{{ ''|otherMetaTags|raw }}
+	{% endif %}
 
     {%- if __SELF__.ogTitle %}
         <meta property="og:title" content="{{ __SELF__.ogTitle }}" />

--- a/components/staticpage/default.htm
+++ b/components/staticpage/default.htm
@@ -2,6 +2,10 @@
     <meta http-equiv="refresh" content="0; url={{__SELF__.redirect_url}}" />
 {% endif -%}
 
+{%- if getSettings('other_tags_position') == 'top' %}
+{{ ''|otherMetaTags|raw }}
+{% endif -%}
+
 {%- if __SELF__.seo_title %}
     <title>{{__SELF__.seo_title | generateTitle }}</title>
 {% else %}
@@ -32,7 +36,9 @@
     <meta name="robots" content="index,follow">
 {% endif -%}
 
+{% if getSettings('other_tags_position') != 'top' %}
 {{ ''|otherMetaTags|raw }}
+{% endif %}
 
 {%- if __SELF__.ogTitle %}
 <meta property="og:title" content="{{ __SELF__.ogTitle }}" />

--- a/components/staticpage/default.htm
+++ b/components/staticpage/default.htm
@@ -1,28 +1,28 @@
-{% if __SELF__.redirect_url %}
+{%- if __SELF__.redirect_url %}
     <meta http-equiv="refresh" content="0; url={{__SELF__.redirect_url}}" />
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.seo_title %}
+{%- if __SELF__.seo_title %}
     <title>{{__SELF__.seo_title | generateTitle }}</title>
 {% else %}
     <title>{{ __SELF__.title | generateTitle }}</title>
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.seo_description %}
+{%- if __SELF__.seo_description %}
     <meta name="description" content="{{__SELF__.seo_description}}">
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.seo_keywords %}
+{%- if __SELF__.seo_keywords %}
     <meta name="keywords" content="{{__SELF__.seo_keywords}}">
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.canonical_url %}
+{%- if __SELF__.canonical_url %}
     <link rel="canonical" href="{{__SELF__.canonical_url}}" />
 {% else %}
     {{ '' | generateCanonicalUrl}}
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.robot_index and __SELF__.robot_follow %}
+{%- if __SELF__.robot_index and __SELF__.robot_follow %}
     <meta name="robots" content="{{__SELF__.robot_index}},{{__SELF__.robot_follow}}">
 {% elseif __SELF__.robot_index %}
     <meta name="robots" content="{{__SELF__.robot_index}},follow">
@@ -30,26 +30,26 @@
     <meta name="robots" content="index,{{__SELF__.robot_follow}}">
 {% else %}
     <meta name="robots" content="index,follow">
-{% endif %}
+{% endif -%}
 
 {{ ''|otherMetaTags|raw }}
 
-{% if __SELF__.ogTitle %}
+{%- if __SELF__.ogTitle %}
 <meta property="og:title" content="{{ __SELF__.ogTitle }}" />
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.ogUrl %}
+{%- if __SELF__.ogUrl %}
 <meta property="og:url" content="{{ __SELF__.ogUrl }}" />
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.ogSiteName %}
+{%- if __SELF__.ogSiteName %}
 <meta property="og:site_name" content="{{ __SELF__.ogSiteName }}" />
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.ogDescription %}
+{%- if __SELF__.ogDescription %}
 <meta property="og:description" content="{{ __SELF__.ogDescription }}" />
-{% endif %}
+{% endif -%}
 
-{% if __SELF__.ogFbAppId %}
+{%- if __SELF__.ogFbAppId %}
 <meta property="fb:app_id" content="{{ __SELF__.ogFbAppId  }}" />
-{% endif %}
+{% endif -%}

--- a/lang/cs/lang.php
+++ b/lang/cs/lang.php
@@ -25,6 +25,10 @@ return [
             'other_tags' => 'Ostatní meta tagy',
             'other_tags_comment_above' => 'Zadejte tagy které chcete přidat na všech stránkách',
             'other_tags_comment' => 'Zadejte meta tagy jako například meta author, meta viewport a další',
+            'other_tags_position' => 'Position other meta tags',
+			'other_tags_position_top' => 'At top of HEAD element',
+			'other_tags_position_bottom' => 'At bottom of HEAD element (before any OG tags)',
+            'other_tags_position_comment' => 'The position of other meta tags in HEAD element',
         ],
         'tab_og' => [
             'label' => 'Open Graph',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -35,6 +35,10 @@
             'other_tags' => 'Other meta tags',
             'other_tags_comment_above' => 'Insert tags that you want to insert in all pages',
             'other_tags_comment' => 'Insert other meta tags like meta author, meta viewport etc',
+            'other_tags_position' => 'Position other meta tags',
+			'other_tags_position_top' => 'At top of HEAD element',
+			'other_tags_position_bottom' => 'At bottom of HEAD element (before any OG tags)',
+            'other_tags_position_comment' => 'The position of other meta tags in HEAD element',
         ],
         'tab_og' => [
             'label' => 'Open Graph',

--- a/lang/ru/lang.php
+++ b/lang/ru/lang.php
@@ -25,6 +25,10 @@ return [
             'other_tags' => 'Другие Мета-теги',
             'other_tags_comment_above' => 'Введите теги, которые вы хотите вставить на все страницы',
             'other_tags_comment' => 'Например,такие теги как author, viewport и т.д.',
+            'other_tags_position' => 'Position other meta tags',
+			'other_tags_position_top' => 'At top of HEAD element',
+			'other_tags_position_bottom' => 'At bottom of HEAD element (before any OG tags)',
+            'other_tags_position_comment' => 'The position of other meta tags in HEAD element',
         ],
         'tab_og' => [
             'label' => 'Open Graph',

--- a/lang/sv/lang.php
+++ b/lang/sv/lang.php
@@ -32,6 +32,10 @@
             'other_tags' => 'Övriga metataggar',
             'other_tags_comment_above' => 'Lägg in taggar du vill antända på alla sidor',
             'other_tags_comment' => 'Lägg in övriga metataggar såsom author, meta viewport etc',
+            'other_tags_position' => 'Position other meta tags',
+			'other_tags_position_top' => 'At top of HEAD element',
+			'other_tags_position_bottom' => 'At bottom of HEAD element (before any OG tags)',
+            'other_tags_position_comment' => 'The position of other meta tags in HEAD element',
         ],
         'tab_og' => [
             'label' => 'Open Graph',

--- a/lang/tr/lang.php
+++ b/lang/tr/lang.php
@@ -25,6 +25,10 @@ return [
             'other_tags' => 'Diğer meta taglar',
             'other_tags_comment_above' => 'Tüm sayfalarda görünmesini istediğiniz etiketleri ekleyin',
             'other_tags_comment' => 'Meta author, meta viewport gibi diğer meta etiketleri ekleyin',
+            'other_tags_position' => 'Position other meta tags',
+			'other_tags_position_top' => 'At top of HEAD element',
+			'other_tags_position_bottom' => 'At bottom of HEAD element (before any OG tags)',
+            'other_tags_position_comment' => 'The position of other meta tags in HEAD element',
         ],
         'tab_og' => [
             'label' => 'Open Graph',

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -44,6 +44,15 @@ tabs:
       commentAbove: suresoftware.powerseo::lang.settings.tab_settings.other_tags_comment_above
       comment: suresoftware.powerseo::lang.settings.tab_settings.other_tags_comment
 
+    other_tags_position:
+      label: suresoftware.powerseo::lang.settings.tab_settings.other_tags_position
+      type: radio
+      tab: suresoftware.powerseo::lang.settings.tab_settings.label      
+      comment: suresoftware.powerseo::lang.settings.tab_settings.other_tags_position_comment
+      options:
+        top: suresoftware.powerseo::lang.settings.tab_settings.other_tags_position_top
+        bottom: suresoftware.powerseo::lang.settings.tab_settings.other_tags_position_bottom
+
     og_tags_description:
       type: hint
       path: $/suresoftware/powerseo/models/settings/_og_tags_description.htm
@@ -67,10 +76,3 @@ tabs:
       type: text
       span: left
       tab: suresoftware.powerseo::lang.settings.tab_og.label
-
-
-
-
-
-
-


### PR DESCRIPTION
I've made two small improvements.

1) Beautifying the meta tags output. Added the spaceless options from Twig to the component templates for this. There are now (almost) no empty lines between each meta tag in the output.

2) Added an extra setting to the plugin which allows users to choose whether they want the "other meta tags" to be added to the top of the HEAD element or near the bottom (default),